### PR TITLE
add package.json; bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "uservoice-trigger-directive",
-	"version": "0.0.3",
+	"version": "0.1.3",
 	"main": "uservoice-trigger-directive.js",
 	"ignore": [
 	],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "uservoice-trigger-directive",
+	"version": "0.1.3",
+	"description": "Simple directive to trigger a UserVoice popup. Requires UserVoice to be included.",
+	"main": "uservoice-trigger-directive.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/chesleybrown/uservoice-trigger-directive.git"
+	},
+	"keywords": [
+		"UserVoice",
+		"Angular",
+		"AngularJS",
+		"directive",
+		"popup"
+	],
+	"author": "Chesley Brown <me@chesleybrown.ca> (http://chesleybrown.ca/)",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/chesleybrown/uservoice-trigger-directive/issues"
+	},
+	"homepage": "https://github.com/chesleybrown/uservoice-trigger-directive"
+}


### PR DESCRIPTION
Adds a package.json file to allow installation via npm (e.g., for use with Browserify):

    npm install troywarr/uservoice-trigger-directive

If you'd like, you can register the npm module `uservoice-trigger-directive` to allow installation very similar to Bower:

    npm install uservoice-trigger-directive

Also includes a minor version bump.