### PR TITLE
Fix triggers on angular strap drop down menu items

### DIFF
--- a/src/directive.uservoice-trigger.js
+++ b/src/directive.uservoice-trigger.js
@@ -5,8 +5,6 @@ angular
 		'service.uservoice'
 	])
 	.directive('uservoiceTrigger', function (UserVoice) {
-		var count = 0;
-		
 		return {
 			restrict: 'A',
 			scope: {
@@ -15,9 +13,6 @@ angular
 				identify: '='
 			},
 			link: function (scope, elem) {
-				elem.attr('id', 'feedback-uservoice-' + count.toString());
-				count = count + 1;
-				
 				if (!scope.position) {
 					scope.position = 'automatic';
 				}
@@ -26,7 +21,10 @@ angular
 				}
 				
 				if (UserVoice) {
-					UserVoice.push(['addTrigger', '#' + elem.attr('id'), {mode: scope.mode, position: scope.position}]);
+					UserVoice.push(['addTrigger', elem[0], {
+						mode: scope.mode,
+						position: scope.position
+					}]);
 				}
 				
 				var setIdentify = function () {

--- a/src/directive.uservoice-trigger.js
+++ b/src/directive.uservoice-trigger.js
@@ -13,6 +13,12 @@ angular
 				identify: '='
 			},
 			link: function (scope, elem) {
+				// if we failed to initialize UserVoice for some reason, e.g.
+				// due to forgetting to configure its API key
+				if (!UserVoice) {
+					return;
+				}
+				
 				if (!scope.position) {
 					scope.position = 'automatic';
 				}
@@ -20,12 +26,10 @@ angular
 					scope.mode = 'contact';
 				}
 				
-				if (UserVoice) {
-					UserVoice.push(['addTrigger', elem[0], {
-						mode: scope.mode,
-						position: scope.position
-					}]);
-				}
+				UserVoice.push(['addTrigger', elem[0], {
+					mode: scope.mode,
+					position: scope.position
+				}]);
 				
 				var setIdentify = function () {
 					if (scope.identify) {

--- a/src/directive.uservoice-trigger.js
+++ b/src/directive.uservoice-trigger.js
@@ -30,6 +30,10 @@ angular
 					mode: scope.mode,
 					position: scope.position
 				}]);
+				scope.$on('$destroy', function () {
+					UserVoice.push(['hide']);
+					UserVoice.push(['removeTrigger', elem[0]]);
+				});
 				
 				var setIdentify = function () {
 					if (scope.identify) {


### PR DESCRIPTION
- passed in raw DOM element reference instead of id to `UserVoice.push()`
- avoided JS error if `UserVoice` init fails and `identify` param is specified
- removed `UserVoice` trigger if DOM element is destroyed

More detailed explanations may be found in the commit descriptions, but in general the changes done here allow us to apply `UserVoice` triggers to angular-strap drop-down menu items which otherwise have the following issues:
- their DOM gets constructed before getting attached to the main DOM
- we want the `UserVoice` dialog to close automatically in case the drop-down menu closes
